### PR TITLE
FEAT : New Endpoint / PHPUNIT / Rename Test 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,3 +50,11 @@ install: ## Install Package Composer
 test:
 	./vendor/bin/phpunit --do-not-cache-result
 .PHONY: test
+
+test-dragon:
+	./vendor/bin/phpunit --do-not-cache-result --group dragon
+.PHONY: test-dragon
+
+test-league:
+	./vendor/bin/phpunit --do-not-cache-result --group league
+.PHONY: test-league

--- a/README.md
+++ b/README.md
@@ -32,22 +32,21 @@ Dans le fichier `.env` de l'environnement souhaité, ajouter :
 API_RIO_BASE_URI='https://ddragon.leagueoflegends.com'
 ```
 
-# Exemple 
+# Exemple
 
 ```php
     namespace App\Controller;
     
-    use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
     use Symfony\Component\HttpFoundation\Response;
     use Symfony\Component\Routing\Annotation\Route;
-    use Zeggriim\RiotApiDataDragon\Endpoint\VersionApiInterface;
+    use Zeggriim\RiotApiDataDragon\Endpoint\DataDragon\VersionApiInterface;
     
     class HomeController
     {
         #[Route('/home', name: 'app_home')]
         public function index(VersionApiInterface $versionApi): Response
         {
-            dd($versionApi->getVersions());
+            $versionApi->getVersions();
             // ['14.8.1','14.7.1','14.6.1','14.5.1','14.4.1'....]
         }
     }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -30,5 +30,13 @@
         <include>
             <directory suffix=".php">src</directory>
         </include>
+
+        <exclude>
+            <directory suffix=".php">src/DependencyInjection</directory>
+            <directory suffix=".php">src/Enum</directory>
+
+            <file>src/RiotApiDataDragonBundle.php</file>
+
+        </exclude>
     </source>
 </phpunit>

--- a/src/Endpoint/DataDragon/ChampionApi.php
+++ b/src/Endpoint/DataDragon/ChampionApi.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Zeggriim\RiotApiDataDragon\Endpoint;
+namespace Zeggriim\RiotApiDataDragon\Endpoint\DataDragon;
 
 use Zeggriim\RiotApiDataDragon\RiotApiDataDragon;
 

--- a/src/Endpoint/DataDragon/ChampionApiInterface.php
+++ b/src/Endpoint/DataDragon/ChampionApiInterface.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Zeggriim\RiotApiDataDragon\Endpoint;
+namespace Zeggriim\RiotApiDataDragon\Endpoint\DataDragon;
 
 interface ChampionApiInterface
 {

--- a/src/Endpoint/DataDragon/ItemApi.php
+++ b/src/Endpoint/DataDragon/ItemApi.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Zeggriim\RiotApiDataDragon\Endpoint;
+namespace Zeggriim\RiotApiDataDragon\Endpoint\DataDragon;
 
 use Zeggriim\RiotApiDataDragon\RiotApiDataDragon;
 

--- a/src/Endpoint/DataDragon/ItemApiInterface.php
+++ b/src/Endpoint/DataDragon/ItemApiInterface.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Zeggriim\RiotApiDataDragon\Endpoint;
+namespace Zeggriim\RiotApiDataDragon\Endpoint\DataDragon;
 
 interface ItemApiInterface
 {

--- a/src/Endpoint/DataDragon/LanguageApi.php
+++ b/src/Endpoint/DataDragon/LanguageApi.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Zeggriim\RiotApiDataDragon\Endpoint;
+namespace Zeggriim\RiotApiDataDragon\Endpoint\DataDragon;
 
 use Zeggriim\RiotApiDataDragon\RiotApiDataDragon;
 

--- a/src/Endpoint/DataDragon/LanguageApiInterface.php
+++ b/src/Endpoint/DataDragon/LanguageApiInterface.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Zeggriim\RiotApiDataDragon\Endpoint;
+namespace Zeggriim\RiotApiDataDragon\Endpoint\DataDragon;
 
 interface LanguageApiInterface
 {

--- a/src/Endpoint/DataDragon/ProfileIconApi.php
+++ b/src/Endpoint/DataDragon/ProfileIconApi.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Zeggriim\RiotApiDataDragon\Endpoint;
+namespace Zeggriim\RiotApiDataDragon\Endpoint\DataDragon;
 
 use Zeggriim\RiotApiDataDragon\RiotApiDataDragon;
 

--- a/src/Endpoint/DataDragon/ProfileIconApiInterface.php
+++ b/src/Endpoint/DataDragon/ProfileIconApiInterface.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Zeggriim\RiotApiDataDragon\Endpoint;
+namespace Zeggriim\RiotApiDataDragon\Endpoint\DataDragon;
 
 interface ProfileIconApiInterface
 {

--- a/src/Endpoint/DataDragon/SummonerApi.php
+++ b/src/Endpoint/DataDragon/SummonerApi.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Zeggriim\RiotApiDataDragon\Endpoint;
+namespace Zeggriim\RiotApiDataDragon\Endpoint\DataDragon;
 
 use Zeggriim\RiotApiDataDragon\RiotApiDataDragon;
 

--- a/src/Endpoint/DataDragon/SummonerApiInterface.php
+++ b/src/Endpoint/DataDragon/SummonerApiInterface.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Zeggriim\RiotApiDataDragon\Endpoint;
+namespace Zeggriim\RiotApiDataDragon\Endpoint\DataDragon;
 
 interface SummonerApiInterface
 {

--- a/src/Endpoint/DataDragon/VersionApi.php
+++ b/src/Endpoint/DataDragon/VersionApi.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Zeggriim\RiotApiDataDragon\Endpoint;
+namespace Zeggriim\RiotApiDataDragon\Endpoint\DataDragon;
 
 use Zeggriim\RiotApiDataDragon\RiotApiDataDragon;
 

--- a/src/Endpoint/DataDragon/VersionApiInterface.php
+++ b/src/Endpoint/DataDragon/VersionApiInterface.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Zeggriim\RiotApiDataDragon\Endpoint;
+namespace Zeggriim\RiotApiDataDragon\Endpoint\DataDragon;
 
 interface VersionApiInterface
 {

--- a/src/Endpoint/DataLeague/LeagueApi.php
+++ b/src/Endpoint/DataLeague/LeagueApi.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zeggriim\RiotApiDataDragon\Endpoint\DataLeague;
+
+use Zeggriim\RiotApiDataDragon\Enum\Division;
+use Zeggriim\RiotApiDataDragon\Enum\Queue;
+use Zeggriim\RiotApiDataDragon\Enum\Tier;
+use Zeggriim\RiotApiDataDragon\RiotApiDataLeague;
+
+class LeagueApi implements LeagueApiInterface
+{
+    private const URL_LEAGUE_CHALLENGER     = '/lol/league/v4/challengerleagues/by-queue/%s';
+    private const URL_LEAGUE_GRANDMASTER    = '/lol/league/v4/grandmasterleagues/by-queue/%s';
+    private const URL_LEAGUE_MASTER         = '/lol/league/v4/masterleagues/by-queue/%s';
+    private const URL_LEAGUE_OTHER          = '/lol/league/v4/entries/%s/%s/%s';
+    private const URL_LEAGUE_ID             = '/lol/league/v4/leagues/%s';
+    private const URL_LEAGUE_SUMMUNER_ID    = '/lol/league/v4/entries/by-summoner/%s';
+
+    public function __construct(private readonly RiotApiDataLeague $riotApiDataLeague) {}
+
+    public function getChallenger(Queue $queue = Queue::RANKED_SOLO): array
+    {
+        $path = sprintf(self::URL_LEAGUE_CHALLENGER, $queue->value);
+        return $this->riotApiDataLeague->get($path);
+    }
+
+    public function getGrandMaster(Queue $queue = Queue::RANKED_SOLO): array
+    {
+        $path = sprintf(self::URL_LEAGUE_GRANDMASTER, $queue->value);
+        return $this->riotApiDataLeague->get($path);
+    }
+
+    public function getMaster(Queue $queue = Queue::RANKED_SOLO): array
+    {
+        $path = sprintf(self::URL_LEAGUE_MASTER, $queue->value);
+        return $this->riotApiDataLeague->get($path);
+    }
+
+    public function getAll(Queue $queue, Tier $tier, Division $division): array
+    {
+        $path = sprintf(self::URL_LEAGUE_OTHER, $queue->value, $tier->value, $division->value);
+        return $this->riotApiDataLeague->get($path);
+    }
+
+    public function getLeagueWithId(string $leagueId): array
+    {
+        $path = sprintf(self::URL_LEAGUE_ID, $leagueId);
+        return $this->riotApiDataLeague->get($path);
+    }
+
+    public function getLeagueInAllQueuesWithSummonerId(string $summonerId): array
+    {
+        $path = sprintf(self::URL_LEAGUE_SUMMUNER_ID, $summonerId);
+        return $this->riotApiDataLeague->get($path);
+    }
+}

--- a/src/Endpoint/DataLeague/LeagueApiInterface.php
+++ b/src/Endpoint/DataLeague/LeagueApiInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Zeggriim\RiotApiDataDragon\Endpoint\DataLeague;
+
+use Zeggriim\RiotApiDataDragon\Enum\Division;
+use Zeggriim\RiotApiDataDragon\Enum\Queue;
+use Zeggriim\RiotApiDataDragon\Enum\Tier;
+
+interface LeagueApiInterface
+{
+    public function getChallenger(Queue $queue): array;
+
+    public function getGrandMaster(Queue $queue): array;
+    public function getMaster(Queue $queue): array;
+
+    public function getAll(Queue $queue, Tier $tier, Division $division): array;
+
+    public function getLeagueWithId(string $leagueId): array;
+
+    public function getLeagueInAllQueuesWithSummonerId(string $summonerId): array;
+}

--- a/src/Enum/Division.php
+++ b/src/Enum/Division.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zeggriim\RiotApiDataDragon\Enum;
+
+enum Division: string
+{
+    case I = 'I';
+    case II = 'II';
+    case III = 'III';
+    case IV = 'IV';
+}

--- a/src/Enum/Queue.php
+++ b/src/Enum/Queue.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zeggriim\RiotApiDataDragon\Enum;
+
+enum Queue: string
+{
+    case RANKED_SOLO = 'RANKED_SOLO_5x5';
+    case RANKED_FLED_SR = 'RANKED_FLED_SR';
+    case RANKED_FLED_TT = 'RANKED_FLED_TT';
+}

--- a/src/Enum/Tier.php
+++ b/src/Enum/Tier.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zeggriim\RiotApiDataDragon\Enum;
+
+enum Tier: string
+{
+    case IRON       = 'IRON';
+    case BRONZE     = 'BRONZE';
+    case SILVER     = 'SILVER';
+    case GOLD       = 'GOLD';
+    case PLATINUM   = 'PLATINUM';
+    case EMERALD    = 'EMERALD';
+    case DIAMOND    = 'DIAMOND';
+}

--- a/src/Resources/Config/services.yaml
+++ b/src/Resources/Config/services.yaml
@@ -3,27 +3,37 @@ services:
         autowire: true
         public: false
 
-    Zeggriim\RiotApiDataDragon\Endpoint\ChampionApi:
+    Zeggriim\RiotApiDataDragon\Endpoint\DataDragon\ChampionApi:
         autowire: true
 
-    Zeggriim\RiotApiDataDragon\Endpoint\ItemApi:
+    Zeggriim\RiotApiDataDragon\Endpoint\DataDragon\ItemApi:
         autowire: true
 
-    Zeggriim\RiotApiDataDragon\Endpoint\LanguageApi:
+    Zeggriim\RiotApiDataDragon\Endpoint\DataDragon\LanguageApi:
         autowire: true
 
-    Zeggriim\RiotApiDataDragon\Endpoint\ProfileIconApi:
+    Zeggriim\RiotApiDataDragon\Endpoint\DataDragon\ProfileIconApi:
         autowire: true
 
-    Zeggriim\RiotApiDataDragon\Endpoint\SummonerApi:
+    Zeggriim\RiotApiDataDragon\Endpoint\DataDragon\SummonerApi:
         autowire: true
 
-    Zeggriim\RiotApiDataDragon\Endpoint\VersionApi:
+    Zeggriim\RiotApiDataDragon\Endpoint\DataDragon\VersionApi:
         autowire: true
 
-    Zeggriim\RiotApiDataDragon\Endpoint\ChampionApiInterface: '@Zeggriim\RiotApiDataDragon\Endpoint\ChampionApi'
-    Zeggriim\RiotApiDataDragon\Endpoint\ItemApiInterface: '@Zeggriim\RiotApiDataDragon\Endpoint\ItemApi'
-    Zeggriim\RiotApiDataDragon\Endpoint\LanguageApiInterface: '@Zeggriim\RiotApiDataDragon\Endpoint\LanguageApi'
-    Zeggriim\RiotApiDataDragon\Endpoint\ProfileIconApiInterface: '@Zeggriim\RiotApiDataDragon\Endpoint\ProfileIconApi'
-    Zeggriim\RiotApiDataDragon\Endpoint\SummonerApiInterface: '@Zeggriim\RiotApiDataDragon\Endpoint\SummonerApi'
-    Zeggriim\RiotApiDataDragon\Endpoint\VersionApiInterface: '@Zeggriim\RiotApiDataDragon\Endpoint\VersionApi'
+    Zeggriim\RiotApiDataDragon\Endpoint\DataDragon\ChampionApiInterface: '@Zeggriim\RiotApiDataDragon\Endpoint\DataDragon\ChampionApi'
+    Zeggriim\RiotApiDataDragon\Endpoint\DataDragon\ItemApiInterface: '@Zeggriim\RiotApiDataDragon\Endpoint\DataDragon\ItemApi'
+    Zeggriim\RiotApiDataDragon\Endpoint\DataDragon\LanguageApiInterface: '@Zeggriim\RiotApiDataDragon\Endpoint\DataDragon\LanguageApi'
+    Zeggriim\RiotApiDataDragon\Endpoint\DataDragon\ProfileIconApiInterface: '@Zeggriim\RiotApiDataDragon\Endpoint\DataDragon\ProfileIconApi'
+    Zeggriim\RiotApiDataDragon\Endpoint\DataDragon\SummonerApiInterface: '@Zeggriim\RiotApiDataDragon\Endpoint\DataDragon\SummonerApi'
+    Zeggriim\RiotApiDataDragon\Endpoint\DataDragon\VersionApiInterface: '@Zeggriim\RiotApiDataDragon\Endpoint\DataDragon\VersionApi'
+
+
+    Zeggriim\RiotApiDataDragon\RiotApiDataLeague:
+        autowire: true
+        public: false
+
+    Zeggriim\RiotApiDataDragon\Endpoint\DataLeague\LeagueApi:
+        autowire: true
+
+    Zeggriim\RiotApiDataDragon\Endpoint\DataLeague\LeagueApiInterface: '@Zeggriim\RiotApiDataDragon\Endpoint\DataLeague\LeagueApi'

--- a/src/RiotApiDataLeague.php
+++ b/src/RiotApiDataLeague.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zeggriim\RiotApiDataDragon;
+
+use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Contracts\HttpClient\Exception\ExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\HttpExceptionInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Zeggriim\RiotApiDataDragon\Enum\Platform;
+
+class RiotApiDataLeague
+{
+    const URL = 'https://%s.api.riotgames.com%s';
+
+    public function __construct(
+        public readonly HttpClientInterface $riotLeague,
+        public readonly LoggerInterface $logger,
+        private Platform $platform = Platform::EUW1
+    ) {}
+
+
+    public function get(string $path): array
+    {
+        $url = sprintf(self::URL, $this->platform->value, $path);
+
+        try {
+            return $this->processRequest(Request::METHOD_GET, $url);
+        } catch (ExceptionInterface $exception) {
+            return [];
+        }
+    }
+
+    private function processRequest(string $method, string $path): array
+    {
+        try {
+            $response = $this->riotLeague->request($method, $path);
+            $response = $response->toArray();
+        } catch (HttpExceptionInterface $exception) {
+            $this->logger->critical(
+                'An error occured when process Riot Api request.',
+                [
+                    'method' => $method,
+                    'request' => $path,
+                    'exception_class' => \get_class($exception),
+                    'exception_message' => $exception->getMessage(),
+                ]
+            );
+
+            throw $exception;
+        }
+
+        return $response;
+    }
+}

--- a/tests/Endpoint/DataDragon/ChampionApiTest.php
+++ b/tests/Endpoint/DataDragon/ChampionApiTest.php
@@ -2,17 +2,20 @@
 
 declare(strict_types=1);
 
-namespace Zeggriim\RiotApiDataDragon\Tests\Endpoint;
+namespace Zeggriim\RiotApiDataDragon\Tests\Endpoint\DataDragon;
 
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
-use Zeggriim\RiotApiDataDragon\Endpoint\ChampionApi;
-use Zeggriim\RiotApiDataDragon\Tests\Traits\CheckerChampionTrait;
+use Zeggriim\RiotApiDataDragon\Endpoint\DataDragon\ChampionApi;
+use Zeggriim\RiotApiDataDragon\Tests\Traits\AssertChampionTrait;
 use Zeggriim\RiotApiDataDragon\Tests\Traits\RiotApiDataDragonTrait;
 
+/**
+ * @group dragon
+ */
 class ChampionApiTest extends KernelTestCase
 {
     use RiotApiDataDragonTrait;
-    use CheckerChampionTrait;
+    use AssertChampionTrait;
 
     public function testGetChampions()
     {
@@ -135,12 +138,12 @@ class ChampionApiTest extends KernelTestCase
 //      Champion 1
         self::assertArrayHasKey('Aatrox', $dataChampions);
         $champion1 = $dataChampions['Aatrox'];
-        $this->checkChampion($data['data']['Aatrox'], $champion1);
+        $this->assertChampion($data['data']['Aatrox'], $champion1);
 
 //      Champion 2
         self::assertArrayHasKey('Akshan', $dataChampions);
         $champion2 = $dataChampions['Akshan'];
-        $this->checkChampion($data['data']['Akshan'], $champion2);
+        $this->assertChampion($data['data']['Akshan'], $champion2);
     }
 
     public function testGetChampion()
@@ -317,6 +320,14 @@ class ChampionApiTest extends KernelTestCase
 
         // Champion
         self::assertArrayHasKey('Aatrox', $dataChampion);
-        $this->checkChampion($data['data']['Aatrox'], $dataChampion['Aatrox'], true);
+        $this->assertChampion($data['data']['Aatrox'], $dataChampion['Aatrox'], true);
+    }
+
+    public function testGetBadRequest()
+    {
+        $riotApi = $this->getClientRiotApi(['test' => 'test'], ['http_code' => 400]);
+        $championApi = new ChampionApi($riotApi);
+        $champion = $championApi->getChampion('aatrox', '14.8.1');
+        self::assertCount(0, $champion);
     }
 }

--- a/tests/Endpoint/DataDragon/ItemApiTest.php
+++ b/tests/Endpoint/DataDragon/ItemApiTest.php
@@ -1,17 +1,20 @@
 <?php
 declare(strict_types=1);
 
-namespace Zeggriim\RiotApiDataDragon\Tests\Endpoint;
+namespace Zeggriim\RiotApiDataDragon\Tests\Endpoint\DataDragon;
 
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
-use Zeggriim\RiotApiDataDragon\Endpoint\ItemApi;
-use Zeggriim\RiotApiDataDragon\Tests\Traits\CheckItemTrait;
+use Zeggriim\RiotApiDataDragon\Endpoint\DataDragon\ItemApi;
+use Zeggriim\RiotApiDataDragon\Tests\Traits\AssertItemTrait;
 use Zeggriim\RiotApiDataDragon\Tests\Traits\RiotApiDataDragonTrait;
 
+/**
+ * @group dragon
+ */
 class ItemApiTest extends KernelTestCase
 {
     use RiotApiDataDragonTrait;
-    use CheckItemTrait;
+    use AssertItemTrait;
 
     public function testGetItems()
     {
@@ -106,6 +109,6 @@ class ItemApiTest extends KernelTestCase
         // Item 1
         self::assertArrayHasKey('1028', $dataItems);
         $champion1 = $dataItems['1028'];
-        $this->checkItem($data['data']['1028'], $champion1);
+        $this->assertItem($data['data']['1028'], $champion1);
     }
 }

--- a/tests/Endpoint/DataDragon/LanguageApiTest.php
+++ b/tests/Endpoint/DataDragon/LanguageApiTest.php
@@ -1,12 +1,15 @@
 <?php
 declare(strict_types=1);
 
-namespace Zeggriim\RiotApiDataDragon\Tests\Endpoint;
+namespace Zeggriim\RiotApiDataDragon\Tests\Endpoint\DataDragon;
 
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
-use Zeggriim\RiotApiDataDragon\Endpoint\LanguageApi;
+use Zeggriim\RiotApiDataDragon\Endpoint\DataDragon\LanguageApi;
 use Zeggriim\RiotApiDataDragon\Tests\Traits\RiotApiDataDragonTrait;
 
+/**
+ * @group dragon
+ */
 class LanguageApiTest extends KernelTestCase
 {
     use RiotApiDataDragonTrait;

--- a/tests/Endpoint/DataDragon/SummonerApiTest.php
+++ b/tests/Endpoint/DataDragon/SummonerApiTest.php
@@ -2,12 +2,15 @@
 
 declare(strict_types=1);
 
-namespace Zeggriim\RiotApiDataDragon\Tests\Endpoint;
+namespace Zeggriim\RiotApiDataDragon\Tests\Endpoint\DataDragon;
 
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
-use Zeggriim\RiotApiDataDragon\Endpoint\SummonerApi;
+use Zeggriim\RiotApiDataDragon\Endpoint\DataDragon\SummonerApi;
 use Zeggriim\RiotApiDataDragon\Tests\Traits\RiotApiDataDragonTrait;
 
+/**
+ * @group dragon
+ */
 class SummonerApiTest extends KernelTestCase
 {
     use RiotApiDataDragonTrait;

--- a/tests/Endpoint/DataDragon/VersionApiTest.php
+++ b/tests/Endpoint/DataDragon/VersionApiTest.php
@@ -1,12 +1,15 @@
 <?php
 declare(strict_types=1);
 
-namespace Zeggriim\RiotApiDataDragon\Tests\Endpoint;
+namespace Zeggriim\RiotApiDataDragon\Tests\Endpoint\DataDragon;
 
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
-use Zeggriim\RiotApiDataDragon\Endpoint\VersionApi;
+use Zeggriim\RiotApiDataDragon\Endpoint\DataDragon\VersionApi;
 use Zeggriim\RiotApiDataDragon\Tests\Traits\RiotApiDataDragonTrait;
 
+/**
+ * @group dragon
+ */
 class VersionApiTest extends KernelTestCase
 {
     use RiotApiDataDragonTrait;

--- a/tests/Endpoint/DataLeague/LeagueApiTest.php
+++ b/tests/Endpoint/DataLeague/LeagueApiTest.php
@@ -1,0 +1,259 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zeggriim\RiotApiDataDragon\Tests\Endpoint\DataLeague;
+
+use Psr\Log\LoggerInterface;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Zeggriim\RiotApiDataDragon\Endpoint\DataLeague\LeagueApi;
+use Zeggriim\RiotApiDataDragon\Enum\Division;
+use Zeggriim\RiotApiDataDragon\Enum\Queue;
+use Zeggriim\RiotApiDataDragon\Enum\Tier;
+use Zeggriim\RiotApiDataDragon\RiotApiDataLeague;
+use Zeggriim\RiotApiDataDragon\Tests\Traits\AssertLeagueTrait;
+
+/**
+ * @group league
+ */
+class LeagueApiTest extends KernelTestCase
+{
+    use AssertLeagueTrait;
+
+    /**
+     * @dataProvider providerLeague
+     */
+    public function testGetBigLeague(array $dataResponse,string $method): void
+    {
+        $leagueApi = $this->getLeagueApi($dataResponse);
+
+        self::assertTrue(method_exists($leagueApi, $method));
+
+        $leagues = $leagueApi->$method();
+
+        self::assertIsArray($leagues);
+        $this->assertLeagueEntryList($leagues, $dataResponse, 2);
+
+        $firstLeague = $leagues['entries'][0];
+        $this->assertLeagueItem($firstLeague, $dataResponse['entries'][0]);
+
+        $secondLeague = $leagues['entries'][1];
+        $this->assertLeagueItem($secondLeague, $dataResponse['entries'][1]);
+    }
+
+    public static function providerLeague(): array
+    {
+        $dataResponse = [
+            'tier' => 'CHALLENGER',
+            'leagueId' => 'f1-22ee-3814-a360-b5a7f45',
+            'queue' => 'RANKED_SOLO_5x5',
+            'name' => 'Nami \'s Alliance',
+            'entries' => [
+                [
+                    'summonerId'=> 'hEVfJbhPOagFBgHHDvOTaCigErxIKw3lKjz9YChqMAZ8lQc',
+                    'leaguePoints'=> 892,
+                    'rank'=> 'I',
+                    'wins'=> 310,
+                    'losses'=> 254,
+                    'veteran'=> false,
+                    'inactive'=> false,
+                    'freshBlood'=> true,
+                    'hotStreak'=> true
+                ],
+                [
+                    'summonerId' => 'tKfbJzZOJ0NVzTiPDFZw7e-5YvoKf7vyNXfb4wxRds4VX0-',
+                    'leaguePoints' => 960,
+                    'rank' => 'I',
+                    'wins' => 189,
+                    'losses' => 140,
+                    'veteran' => false,
+                    'inactive' => false,
+                    'freshBlood' => false,
+                    'hotStreak' => false
+                ]
+            ]
+        ];
+
+        return [
+            'Challenger' => [
+                'dataResponse' => $dataResponse,
+                'method' => 'getChallenger'
+            ],
+            'Grand Master' => [
+                'dataResponse' => $dataResponse,
+                'method' => 'getGrandMaster'
+            ],
+            'Master' => [
+                'dataResponse' => $dataResponse,
+                'method' => 'getMaster'
+            ],
+        ];
+    }
+
+    public function testGetAllWithDivisionTierQueue()
+    {
+        $dataResponse = [
+            [
+                "leagueId"=> "3437378e-b857-4b1e-b554-4598f31dd36a",
+                "queueType"=> "RANKED_FLEX_SR",
+                "tier"=> "GOLD",
+                "rank"=> "I",
+                "summonerId"=> "T1e3zoiqAc5gNv88a6EhUktK3InEtscj6rXKjUyhApQCFwJ0",
+                "leaguePoints"=> 82,
+                "wins"=> 9,
+                "losses"=> 5,
+                "veteran"=> false,
+                "inactive"=> false,
+                "freshBlood"=> false,
+                "hotStreak"=> false
+            ],
+            [
+                "leagueId"=> "80c6f19e-56d4-4da6-ad25-0338314e5fa7",
+                "queueType"=> "RANKED_FLEX_SR",
+                "tier"=> "GOLD",
+                "rank"=> "I",
+                "summonerId"=> "jSjP7GyZY4j9STVYwxnNvKO7VGNZL27oDiT79K9TSRGsnDDn",
+                "leaguePoints"=> 50,
+                "wins"=> 2,
+                "losses"=> 8,
+                "veteran"=> false,
+                "inactive"=> false,
+                "freshBlood"=> false,
+                "hotStreak"=> false
+            ],
+        ];
+
+        $leagueApi = $this->getLeagueApi($dataResponse);
+        $leagues = $leagueApi->getAll(Queue::RANKED_FLED_SR, Tier::GOLD, Division::I);
+
+        $firstLeague = $leagues[0];
+        $this->assertLeagueEntry($firstLeague, $dataResponse[0]);
+
+        $secondLeague = $leagues[1];
+        $this->assertLeagueEntry($secondLeague, $dataResponse[1]);
+    }
+
+    public function testGetLeagueWithId()
+    {
+        $dataResponse = [
+            "tier"=> "GOLD",
+            "leagueId"=> "3437378e-b857-4b1e-b554-4598f31dd36a",
+            "queue"=> "RANKED_FLEX_SR",
+            "name"=> "Dr. Mundo's Inquisitors",
+            "entries"=> [
+                [
+                    "summonerId"=> "YIhWs5RLvg0K1TvICE0Z0lRq9qYe0vEqJ5NYD7It72q_Ddc",
+                    "leaguePoints"=> 0,
+                    "rank"=> "IV",
+                    "wins"=> 51,
+                    "losses"=> 40,
+                    "veteran"=> false,
+                    "inactive"=> false,
+                    "freshBlood"=> false,
+                    "hotStreak"=> false
+                ],
+                [
+                    "summonerId"=> "GM87Q1cVqHNsqgXBEFp0nul27BP1UJBknFYTpBp6wsODeqI",
+                    "leaguePoints"=> 36,
+                    "rank"=> "IV",
+                    "wins"=> 15,
+                    "losses"=> 8,
+                    "veteran"=> false,
+                    "inactive"=> false,
+                    "freshBlood"=> false,
+                    "hotStreak"=> false
+                ],
+                [
+                    "summonerId"=> "9c5xsKUES_hOp1dVnyJ216Sjr3Syukou11xgjFoDEjatpNE",
+                    "leaguePoints"=> 41,
+                    "rank"=> "IV",
+                    "wins"=> 19,
+                    "losses"=> 16,
+                    "veteran"=> false,
+                    "inactive"=> false,
+                    "freshBlood"=> false,
+                    "hotStreak"=> false
+                ]
+            ]
+        ];
+
+        $leagueApi = $this->getLeagueApi($dataResponse);
+        $leagues = $leagueApi->getLeagueWithId('3437378e-b857-4b1e-b554-4598f31dd36a');
+
+        $this->assertLeagueEntryList($leagues, $dataResponse, 3);
+
+        $firstLeague = $leagues['entries'][0];
+
+        $this->assertLeagueItem($firstLeague, $dataResponse['entries'][0]);
+        $secondLeague = $leagues['entries'][1];
+        $this->assertLeagueItem($secondLeague, $dataResponse['entries'][1]);
+        $thirdLeague = $leagues['entries'][2];
+        $this->assertLeagueItem($thirdLeague, $dataResponse['entries'][2]);
+    }
+
+    public function testGetLeagueWithSummonerId()
+    {
+        $dataResponse = [
+            [
+                "leagueId"      => "3437378e-b857-4b1e-b554-4598f31dd36a",
+                "queueType"     => "RANKED_FLEX_SR",
+                "tier"          => "GOLD",
+                "rank"          => "IV",
+                "summonerId"    => "YIhWs5RLvg0K1TvICE0Z0lRq9qYe0vEqJ5NYD7It72q_Ddc",
+                "leaguePoints"  => 0,
+                "wins"          => 51,
+                "losses"        => 40,
+                "veteran"       => false,
+                "inactive"      => false,
+                "freshBlood"    => false,
+                "hotStreak"     => false
+            ],
+            [
+                "leagueId"      => "b9872597-386f-4db4-b79a-fa952cb3471f",
+                "queueType"     => "RANKED_SOLO_5x5",
+                "tier"          => "BRONZE",
+                "rank"          => "II",
+                "summonerId"    => "YIhWs5RLvg0K1TvICE0Z0lRq9qYe0vEqJ5NYD7It72q_Ddc",
+                "leaguePoints"  => 45,
+                "wins"          => 76,
+                "losses"        => 89,
+                "veteran"       => false,
+                "inactive"      => false,
+                "freshBlood"    => false,
+                "hotStreak"     => false
+            ]
+        ];
+
+        $leagueApi = $this->getLeagueApi($dataResponse);
+        $leagues = $leagueApi->getLeagueInAllQueuesWithSummonerId('YIhWs5RLvg0K1TvICE0Z0lRq9qYe0vEqJ5NYD7It72q_Ddc');
+
+        $firstLeague = $leagues[0];
+        $this->assertLeagueEntry($firstLeague, $dataResponse[0]);
+        $secondLeague = $leagues[1];
+        $this->assertLeagueEntry($secondLeague, $dataResponse[1]);
+    }
+
+    public function testGetBadRequest()
+    {
+        $leagueApi = $this->getLeagueApi(['test'=> 'test'], ['http_code' => 400]);
+        $res = $leagueApi->getGrandMaster();
+        self::assertCount(0, $res);
+    }
+
+    private function getLeagueApi(array $dataResponse, array $info = ['http_code' => 200]): LeagueApi
+    {
+        return new LeagueApi($this->getClientRiotApiDataLeague($dataResponse, $info));
+    }
+
+    private function getClientRiotApiDataLeague(array $data,array $info = ['http_code' => 200]): RiotApiDataLeague
+    {
+        $response = new MockResponse(json_encode($data), $info);
+        $this->createMock(HttpClientInterface::class);
+        $httpClient = new MockHttpClient($response, null);
+        $logger = $this->createMock(LoggerInterface::class);
+        return new RiotApiDataLeague($httpClient, $logger);
+    }
+}

--- a/tests/Traits/AssertChampionTrait.php
+++ b/tests/Traits/AssertChampionTrait.php
@@ -2,19 +2,19 @@
 
 namespace Zeggriim\RiotApiDataDragon\Tests\Traits;
 
-use Zeggriim\RiotApiDataDragon\Tests\Traits\Checker\CheckerImageTrait;
-use Zeggriim\RiotApiDataDragon\Tests\Traits\Checker\CheckerInfoTrait;
-use Zeggriim\RiotApiDataDragon\Tests\Traits\Checker\CheckerPassiveTrait;
-use Zeggriim\RiotApiDataDragon\Tests\Traits\Checker\CheckerStatTrait;
+use Zeggriim\RiotApiDataDragon\Tests\Traits\Checker\AssertImageTrait;
+use Zeggriim\RiotApiDataDragon\Tests\Traits\Checker\AssertInfoTrait;
+use Zeggriim\RiotApiDataDragon\Tests\Traits\Checker\AssertPassiveTrait;
+use Zeggriim\RiotApiDataDragon\Tests\Traits\Checker\AssertStatTrait;
 
-trait CheckerChampionTrait
+trait AssertChampionTrait
 {
-    use CheckerStatTrait;
-    use CheckerInfoTrait;
-    use CheckerImageTrait;
-    use CheckerPassiveTrait;
+    use AssertStatTrait;
+    use AssertInfoTrait;
+    use AssertImageTrait;
+    use AssertPassiveTrait;
 
-    private function checkChampion(array $dataSend, array $champion,bool $isDetail = false): void
+    private function assertChampion(array $dataSend, array $champion, bool $isDetail = false): void
     {
         self::assertArrayHasKey('id', $champion);
         self::assertSame($dataSend['id'], $champion['id']);
@@ -28,10 +28,10 @@ trait CheckerChampionTrait
         self::assertSame($dataSend['blurb'], $champion['blurb']);
 
         self::assertArrayHasKey('info', $champion);
-        $this->checkInfo($dataSend['info'], $champion['info']);
+        $this->assertInfo($dataSend['info'], $champion['info']);
 
         self::assertArrayHasKey('image', $champion);
-        $this->checkImage($dataSend['image'], $champion['image']);
+        $this->assertImage($dataSend['image'], $champion['image']);
 
         self::assertArrayHasKey('tags', $champion);
         self::assertSame($dataSend['tags'], $champion['tags']);
@@ -59,7 +59,7 @@ trait CheckerChampionTrait
             }
 
             self::assertArrayHasKey('passive', $champion);
-            $this->checkPassive($dataSend['passive'], $champion['passive']);
+            $this->assertPassive($dataSend['passive'], $champion['passive']);
         }
     }
 }

--- a/tests/Traits/AssertItemTrait.php
+++ b/tests/Traits/AssertItemTrait.php
@@ -2,13 +2,13 @@
 
 namespace Zeggriim\RiotApiDataDragon\Tests\Traits;
 
-use Zeggriim\RiotApiDataDragon\Tests\Traits\Checker\CheckerImageTrait;
+use Zeggriim\RiotApiDataDragon\Tests\Traits\Checker\AssertImageTrait;
 
-trait CheckItemTrait
+trait AssertItemTrait
 {
-    use CheckerImageTrait;
+    use AssertImageTrait;
 
-    private function checkItem(array $dataItem, array $item):void
+    private function assertItem(array $dataItem, array $item):void
     {
         self::assertArrayHasKey('name', $item);
         self::assertSame($dataItem['name'], $item['name']);
@@ -20,16 +20,16 @@ trait CheckItemTrait
         self::assertSame($dataItem['plaintext'], $item['plaintext']);
 
         self::assertArrayHasKey('image', $item);
-        $this->checkImage($dataItem['image'], $item['image']);
+        $this->assertImage($dataItem['image'], $item['image']);
 
         self::assertArrayHasKey('gold', $item);
-        $this->checkGold($dataItem['gold'], $item['gold']);
+        $this->assertGold($dataItem['gold'], $item['gold']);
 
         self::assertArrayHasKey('maps', $item);
-        $this->checkMap($dataItem['maps'], $item['maps']);
+        $this->assertMap($dataItem['maps'], $item['maps']);
     }
 
-    private function checkGold($dataGold, $gold): void
+    private function assertGold($dataGold, $gold): void
     {
         self::assertArrayHasKey('base', $gold);
         self::assertSame($dataGold['base'], $gold['base']);
@@ -41,7 +41,7 @@ trait CheckItemTrait
         self::assertSame($dataGold['sell'], $gold['sell']);
     }
 
-    private function checkMap($dataMap, $map): void
+    private function assertMap($dataMap, $map): void
     {
         self::assertArrayHasKey(11, $map);
         self::assertSame($dataMap[11], $map[11]);

--- a/tests/Traits/AssertLeagueTrait.php
+++ b/tests/Traits/AssertLeagueTrait.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Zeggriim\RiotApiDataDragon\Tests\Traits;
+
+trait AssertLeagueTrait
+{
+    private function assertLeagueItem(array $dataLeague, array $dataResponse): void
+    {
+        self::assertArrayHasKey('summonerId', $dataLeague);
+        self::assertSame($dataLeague['summonerId'], $dataResponse['summonerId']);
+        self::assertArrayHasKey('leaguePoints', $dataLeague);
+        self::assertSame($dataLeague['leaguePoints'], $dataResponse['leaguePoints']);
+        self::assertArrayHasKey('rank', $dataLeague);
+        self::assertSame($dataLeague['rank'], $dataResponse['rank']);
+        self::assertArrayHasKey('wins', $dataLeague);
+        self::assertSame($dataLeague['wins'], $dataResponse['wins']);
+        self::assertArrayHasKey('losses', $dataLeague);
+        self::assertSame($dataLeague['losses'], $dataResponse['losses']);
+        self::assertArrayHasKey('veteran', $dataLeague);
+        self::assertSame($dataLeague['veteran'], $dataResponse['veteran']);
+        self::assertArrayHasKey('inactive', $dataLeague);
+        self::assertSame($dataLeague['inactive'], $dataResponse['inactive']);
+        self::assertArrayHasKey('freshBlood', $dataLeague);
+        self::assertSame($dataLeague['freshBlood'], $dataResponse['freshBlood']);
+        self::assertArrayHasKey('hotStreak', $dataLeague);
+        self::assertSame($dataLeague['hotStreak'], $dataResponse['hotStreak']);
+    }
+
+    private function assertLeagueEntry(array $dataLeague, array $dataResponse): void
+    {
+        self::assertArrayHasKey('leagueId', $dataLeague);
+        self::assertSame($dataLeague['leagueId'], $dataResponse['leagueId']);
+        self::assertArrayHasKey('leaguePoints', $dataLeague);
+        self::assertSame($dataLeague['leaguePoints'], $dataResponse['leaguePoints']);
+        self::assertArrayHasKey('tier', $dataLeague);
+        self::assertSame($dataLeague['tier'], $dataResponse['tier']);
+        self::assertArrayHasKey('rank', $dataLeague);
+        self::assertSame($dataLeague['rank'], $dataResponse['rank']);
+        self::assertArrayHasKey('summonerId', $dataLeague);
+        self::assertSame($dataLeague['summonerId'], $dataResponse['summonerId']);
+        self::assertArrayHasKey('leaguePoints', $dataLeague);
+        self::assertSame($dataLeague['leaguePoints'], $dataResponse['leaguePoints']);
+        self::assertArrayHasKey('wins', $dataLeague);
+        self::assertSame($dataLeague['wins'], $dataResponse['wins']);
+        self::assertArrayHasKey('losses', $dataLeague);
+        self::assertSame($dataLeague['losses'], $dataResponse['losses']);
+        self::assertArrayHasKey('veteran', $dataLeague);
+        self::assertSame($dataLeague['veteran'], $dataResponse['veteran']);
+        self::assertArrayHasKey('inactive', $dataLeague);
+        self::assertSame($dataLeague['inactive'], $dataResponse['inactive']);
+        self::assertArrayHasKey('freshBlood', $dataLeague);
+        self::assertSame($dataLeague['freshBlood'], $dataResponse['freshBlood']);
+        self::assertArrayHasKey('hotStreak', $dataLeague);
+        self::assertSame($dataLeague['hotStreak'], $dataResponse['hotStreak']);
+    }
+
+    public function assertLeagueEntryList(array $dataLeague, array $dataResponse,int $nbList)
+    {
+
+        self::assertArrayHasKey('tier', $dataLeague);
+        self::assertSame($dataLeague['tier'], $dataResponse['tier']);
+        self::assertArrayHasKey('leagueId', $dataLeague);
+        self::assertSame($dataLeague['leagueId'], $dataResponse['leagueId']);
+        self::assertArrayHasKey('queue', $dataLeague);
+        self::assertSame($dataLeague['queue'], $dataResponse['queue']);
+        self::assertArrayHasKey('name', $dataLeague);
+        self::assertSame($dataLeague['name'], $dataResponse['name']);
+        self::assertArrayHasKey('entries', $dataLeague);
+        self::assertCount($nbList, $dataLeague['entries']);
+    }
+}

--- a/tests/Traits/Checker/AssertImageTrait.php
+++ b/tests/Traits/Checker/AssertImageTrait.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Zeggriim\RiotApiDataDragon\Tests\Traits\Checker;
 
-trait CheckerImageTrait
+trait AssertImageTrait
 {
-    private function checkImage(array $dataImage, array $image): void
+    private function assertImage(array $dataImage, array $image): void
     {
         self::assertArrayHasKey('full', $image);
         self::assertSame($dataImage['full'], $image['full']);

--- a/tests/Traits/Checker/AssertInfoTrait.php
+++ b/tests/Traits/Checker/AssertInfoTrait.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Zeggriim\RiotApiDataDragon\Tests\Traits\Checker;
 
-trait CheckerInfoTrait
+trait AssertInfoTrait
 {
-    private function checkInfo(array $dataInfo, array $info): void
+    private function assertInfo(array $dataInfo, array $info): void
     {
         self::assertArrayHasKey('attack', $info);
         self::assertSame($dataInfo['attack'], $info['attack']);

--- a/tests/Traits/Checker/AssertPassiveTrait.php
+++ b/tests/Traits/Checker/AssertPassiveTrait.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Zeggriim\RiotApiDataDragon\Tests\Traits\Checker;
 
-trait CheckerPassiveTrait
+trait AssertPassiveTrait
 {
-    private function checkPassive(array $dataPassive, array $passive): void
+    private function assertPassive(array $dataPassive, array $passive): void
     {
         self::assertArrayHasKey('name', $passive);
         self::assertSame($dataPassive['name'], $passive['name']);
@@ -15,6 +15,6 @@ trait CheckerPassiveTrait
         self::assertSame($dataPassive['description'], $passive['description']);
 
         self::assertArrayHasKey('image', $passive);
-        $this->checkImage($dataPassive['image'], $passive['image']);
+        $this->assertImage($dataPassive['image'], $passive['image']);
     }
 }

--- a/tests/Traits/Checker/AssertStatTrait.php
+++ b/tests/Traits/Checker/AssertStatTrait.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Zeggriim\RiotApiDataDragon\Tests\Traits\Checker;
 
-trait CheckerStatTrait
+trait AssertStatTrait
 {
     public function checkStat(array $dataStats, array $stats): void
     {

--- a/tests/Traits/RiotApiDataDragonTrait.php
+++ b/tests/Traits/RiotApiDataDragonTrait.php
@@ -10,9 +10,9 @@ use Zeggriim\RiotApiDataDragon\RiotApiDataDragon;
 
 trait RiotApiDataDragonTrait
 {
-    private function getClientRiotApi(array $data): RiotApiDataDragon
+    private function getClientRiotApi(array $data, array $info = ['http_code' => 200]): RiotApiDataDragon
     {
-        $response = new MockResponse(json_encode($data));
+        $response = new MockResponse(json_encode($data), $info);
         $this->createMock(HttpClientInterface::class);
         $httpClient = new MockHttpClient($response, 'https://api.riot.io/api/v1/');
         $logger = $this->createMock(LoggerInterface::class);


### PR DESCRIPTION
- Séparation de endpoint DataDragon et DataLeague
- New Endpoint LeagueApi + test
- Rename Checker to Assert
- PHPUNIT Config Exclude DependencyInjection/Enum