### PR TITLE
 refactor(routing): unify API routing with RoutingInterface and Platform

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -4,6 +4,7 @@ services:
         arguments:
             $apiKey: '%env(string:API_RIOT_KEY)%'
             $defaultPlatform: '%env(enum:Zeggriim\RiotApiDataDragon\Enum\Platform:RIOT_DEFAULT_PLATFORM)%'
+            $defaultRegion: '%env(enum:Zeggriim\RiotApiDataDragon\Enum\Region:RIOT_DEFAULT_REGION)%'
 
 
     # Endpoint Data Dragon

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3"
-
 services:
   php:
     container_name: riot-api-data-dragon-php

--- a/src/DataLeague/Endpoint/AccountApi.php
+++ b/src/DataLeague/Endpoint/AccountApi.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Zeggriim\RiotApiDataDragon\DataLeague\Endpoint;
 
-use Zeggriim\RiotApiDataDragon\Enum\Region;
+use Zeggriim\RiotApiDataDragon\Enum\Platform;
 use Zeggriim\RiotApiDataDragon\RiotApiDataLeagueClient;
 
 class AccountApi implements AccountApiInterface
@@ -17,22 +17,22 @@ class AccountApi implements AccountApiInterface
     {
     }
 
-    public function getAccountByPuuid(string $puuid, ?Region $region = null): array
+    public function getAccountByPuuid(string $puuid, ?Platform $platform = null): array
     {
         $path = \sprintf(self::URL_ACCOUNT_BY_PUUID, $puuid);
 
-        return $this->riotApiDataLeagueClient->get($path, $region)->toArray();
+        return $this->riotApiDataLeagueClient->get($path, ($platform ?? $this->riotApiDataLeagueClient->getDefaultPlatform())->toRegion())->toArray();
     }
 
-    public function getAccountByRiotId(string $gameName, string $tagLine, ?Region $region = null): array
+    public function getAccountByRiotId(string $gameName, string $tagLine, ?Platform $platform = null): array
     {
         $path = \sprintf(self::URL_ACCOUNT_BY_RIOT_ID, $gameName, $tagLine);
 
-        return $this->riotApiDataLeagueClient->get($path, $region)->toArray();
+        return $this->riotApiDataLeagueClient->get($path, ($platform ?? $this->riotApiDataLeagueClient->getDefaultPlatform())->toRegion())->toArray();
     }
 
-    public function getAccountByAccessToken(?Region $region = null): array
+    public function getAccountByAccessToken(?Platform $platform = null): array
     {
-        return $this->riotApiDataLeagueClient->get(self::URL_ACCOUNT_ME, $region)->toArray();
+        return $this->riotApiDataLeagueClient->get(self::URL_ACCOUNT_ME, ($platform ?? $this->riotApiDataLeagueClient->getDefaultPlatform())->toRegion())->toArray();
     }
 }

--- a/src/DataLeague/Endpoint/AccountApiInterface.php
+++ b/src/DataLeague/Endpoint/AccountApiInterface.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Zeggriim\RiotApiDataDragon\DataLeague\Endpoint;
 
-use Zeggriim\RiotApiDataDragon\Enum\Region;
+use Zeggriim\RiotApiDataDragon\Enum\Platform;
 
 interface AccountApiInterface
 {
@@ -13,19 +13,19 @@ interface AccountApiInterface
      *
      * @return array Account data with gameName, tagLine, and puuid
      */
-    public function getAccountByPuuid(string $puuid, ?Region $region = null): array;
+    public function getAccountByPuuid(string $puuid, ?Platform $platform = null): array;
 
     /**
      * Get account by Riot ID (gameName + tagLine).
      *
      * @return array Account data with gameName, tagLine, and puuid
      */
-    public function getAccountByRiotId(string $gameName, string $tagLine, ?Region $region = null): array;
+    public function getAccountByRiotId(string $gameName, string $tagLine, ?Platform $platform = null): array;
 
     /**
      * Get active account by access token (requires OAuth).
      *
      * @return array Account data with gameName, tagLine, and puuid
      */
-    public function getAccountByAccessToken(?Region $region = null): array;
+    public function getAccountByAccessToken(?Platform $platform = null): array;
 }

--- a/src/DataLeague/Endpoint/ChampionApi.php
+++ b/src/DataLeague/Endpoint/ChampionApi.php
@@ -17,6 +17,6 @@ class ChampionApi implements ChampionApiInterface
 
     public function getChampionRotation(?Platform $platform = null): array
     {
-        return $this->riotApiDataLeague->get(self::URL_CHAMPION_ROTATION, $platform)->toArray();
+        return $this->riotApiDataLeague->get(self::URL_CHAMPION_ROTATION, $platform ?? $this->riotApiDataLeague->getDefaultPlatform())->toArray();
     }
 }

--- a/src/DataLeague/Endpoint/ChampionMasteryApi.php
+++ b/src/DataLeague/Endpoint/ChampionMasteryApi.php
@@ -27,7 +27,7 @@ class ChampionMasteryApi implements ChampionMasteryApiInterface
     {
         $url = \sprintf(self::URL_ALL_MASTERIES, $puuid);
 
-        $championMasteriesData = $this->riotApiDataLeagueClient->get($url, $platform)->toArray();
+        $championMasteriesData = $this->riotApiDataLeagueClient->get($url, $platform ?? $this->riotApiDataLeagueClient->getDefaultPlatform())->toArray();
 
         return $this->denormalizer->denormalize($championMasteriesData, ChampionMasteryCollection::class);
     }
@@ -36,14 +36,14 @@ class ChampionMasteryApi implements ChampionMasteryApiInterface
     {
         $url = \sprintf(self::URL_ALL_MASTERIES, $puuid);
 
-        return $this->riotApiDataLeagueClient->get($url, $platform)->toArray();
+        return $this->riotApiDataLeagueClient->get($url, $platform ?? $this->riotApiDataLeagueClient->getDefaultPlatform())->toArray();
     }
 
     public function getChampionMasteryAsObject(string $puuid, int $championId, ?Platform $platform = null): ChampionMastery
     {
         $url = \sprintf(self::URL_MASTERY_BY_CHAMPION, $puuid, $championId);
 
-        $championMasteyData = $this->riotApiDataLeagueClient->get($url, $platform)->toArray();
+        $championMasteyData = $this->riotApiDataLeagueClient->get($url, $platform ?? $this->riotApiDataLeagueClient->getDefaultPlatform())->toArray();
 
         return $this->denormalizer->denormalize($championMasteyData, ChampionMastery::class);
     }
@@ -52,7 +52,7 @@ class ChampionMasteryApi implements ChampionMasteryApiInterface
     {
         $url = \sprintf(self::URL_MASTERY_BY_CHAMPION, $puuid, $championId);
 
-        return $this->riotApiDataLeagueClient->get($url, $platform)->toArray();
+        return $this->riotApiDataLeagueClient->get($url, $platform ?? $this->riotApiDataLeagueClient->getDefaultPlatform())->toArray();
     }
 
     public function getTopChampionMasteriesAsCollection(string $puuid, ?Platform $platform = null, ?int $count = null): ChampionMasteryCollection
@@ -63,7 +63,7 @@ class ChampionMasteryApi implements ChampionMasteryApiInterface
             $url .= '?count='.$count;
         }
 
-        $championMasteriesData = $this->riotApiDataLeagueClient->get($url, $platform)->toArray();
+        $championMasteriesData = $this->riotApiDataLeagueClient->get($url, $platform ?? $this->riotApiDataLeagueClient->getDefaultPlatform())->toArray();
 
         return $this->denormalizer->denormalize($championMasteriesData, ChampionMasteryCollection::class);
     }
@@ -76,13 +76,13 @@ class ChampionMasteryApi implements ChampionMasteryApiInterface
             $url .= '?count='.$count;
         }
 
-        return $this->riotApiDataLeagueClient->get($url, $platform)->toArray();
+        return $this->riotApiDataLeagueClient->get($url, $platform ?? $this->riotApiDataLeagueClient->getDefaultPlatform())->toArray();
     }
 
     public function getTotalMasteryScore(string $puuid, ?Platform $platform = null): int
     {
         $url = \sprintf(self::URL_TOTAL_SCORE, $puuid);
-        $responseArray = $this->riotApiDataLeagueClient->get($url, $platform)->toArray();
+        $responseArray = $this->riotApiDataLeagueClient->get($url, $platform ?? $this->riotApiDataLeagueClient->getDefaultPlatform())->toArray();
 
         return $responseArray[array_key_first($responseArray)];
     }

--- a/src/DataLeague/Endpoint/LeagueApi.php
+++ b/src/DataLeague/Endpoint/LeagueApi.php
@@ -27,41 +27,41 @@ class LeagueApi implements LeagueApiInterface
     {
         $path = \sprintf(self::URL_LEAGUE_CHALLENGER, $queue->value);
 
-        return $this->riotApiDataLeague->get($path, $platform)->toArray();
+        return $this->riotApiDataLeague->get($path, $platform ?? $this->riotApiDataLeague->getDefaultPlatform())->toArray();
     }
 
     public function getGrandMaster(?Platform $platform = null, Queue $queue = Queue::RANKED_SOLO): array
     {
         $path = \sprintf(self::URL_LEAGUE_GRANDMASTER, $queue->value);
 
-        return $this->riotApiDataLeague->get($path, $platform)->toArray();
+        return $this->riotApiDataLeague->get($path, $platform ?? $this->riotApiDataLeague->getDefaultPlatform())->toArray();
     }
 
     public function getMaster(?Platform $platform = null, Queue $queue = Queue::RANKED_SOLO): array
     {
         $path = \sprintf(self::URL_LEAGUE_MASTER, $queue->value);
 
-        return $this->riotApiDataLeague->get($path, $platform)->toArray();
+        return $this->riotApiDataLeague->get($path, $platform ?? $this->riotApiDataLeague->getDefaultPlatform())->toArray();
     }
 
     public function getAll(Queue $queue, Tier $tier, Division $division, ?Platform $platform = null): array
     {
         $path = \sprintf(self::URL_LEAGUE_OTHER, $queue->value, $tier->value, $division->value);
 
-        return $this->riotApiDataLeague->get($path, $platform)->toArray();
+        return $this->riotApiDataLeague->get($path, $platform ?? $this->riotApiDataLeague->getDefaultPlatform())->toArray();
     }
 
     public function getLeagueWithId(string $leagueId, ?Platform $platform = null): array
     {
         $path = \sprintf(self::URL_LEAGUE_ID, $leagueId);
 
-        return $this->riotApiDataLeague->get($path, $platform)->toArray();
+        return $this->riotApiDataLeague->get($path, $platform ?? $this->riotApiDataLeague->getDefaultPlatform())->toArray();
     }
 
     public function getLeagueInAllQueuesWithSummonerId(string $summonerId, ?Platform $platform = null): array
     {
         $path = \sprintf(self::URL_LEAGUE_SUMMUNER_ID, $summonerId);
 
-        return $this->riotApiDataLeague->get($path, $platform)->toArray();
+        return $this->riotApiDataLeague->get($path, $platform ?? $this->riotApiDataLeague->getDefaultPlatform())->toArray();
     }
 }

--- a/src/DataLeague/Endpoint/MatchApi.php
+++ b/src/DataLeague/Endpoint/MatchApi.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Zeggriim\RiotApiDataDragon\DataLeague\Endpoint;
 
 use Zeggriim\RiotApiDataDragon\DataLeague\Filter\MatchFilter;
-use Zeggriim\RiotApiDataDragon\Enum\Region;
+use Zeggriim\RiotApiDataDragon\Enum\Platform;
 use Zeggriim\RiotApiDataDragon\RiotApiDataLeagueClient;
 
 class MatchApi implements MatchApiInterface
@@ -18,7 +18,7 @@ class MatchApi implements MatchApiInterface
     {
     }
 
-    public function getMatches(string $puuidSummoner, ?Region $region = null, ?MatchFilter $filter = null): array
+    public function getMatches(string $puuidSummoner, ?Platform $platform = null, ?MatchFilter $filter = null): array
     {
         $url = \sprintf(self::URL_MATCHES, $puuidSummoner);
 
@@ -26,20 +26,20 @@ class MatchApi implements MatchApiInterface
             $url .= $filter->toQueryString();
         }
 
-        return $this->riotApiDataLeague->get($url, $region)->toArray();
+        return $this->riotApiDataLeague->get($url, ($platform ?? $this->riotApiDataLeague->getDefaultPlatform())->toRegion())->toArray();
     }
 
-    public function getMatch(string $idMatch, ?Region $region = null): array
+    public function getMatch(string $idMatch, ?Platform $platform = null): array
     {
         $url = \sprintf(self::URL_MATCH, $idMatch);
 
-        return $this->riotApiDataLeague->get($url, $region)->toArray();
+        return $this->riotApiDataLeague->get($url, ($platform ?? $this->riotApiDataLeague->getDefaultPlatform())->toRegion())->toArray();
     }
 
-    public function getMatchTimeline(string $idMatch, ?Region $region = null): array
+    public function getMatchTimeline(string $idMatch, ?Platform $platform = null): array
     {
         $url = \sprintf(self::URL_MATCH_TIMELINE, $idMatch);
 
-        return $this->riotApiDataLeague->get($url, $region)->toArray();
+        return $this->riotApiDataLeague->get($url, ($platform ?? $this->riotApiDataLeague->getDefaultPlatform())->toRegion())->toArray();
     }
 }

--- a/src/DataLeague/Endpoint/MatchApiInterface.php
+++ b/src/DataLeague/Endpoint/MatchApiInterface.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Zeggriim\RiotApiDataDragon\DataLeague\Endpoint;
 
 use Zeggriim\RiotApiDataDragon\DataLeague\Filter\MatchFilter;
-use Zeggriim\RiotApiDataDragon\Enum\Region;
+use Zeggriim\RiotApiDataDragon\Enum\Platform;
 
 interface MatchApiInterface
 {
@@ -14,19 +14,19 @@ interface MatchApiInterface
      *
      * @return array<string> List of match IDs
      */
-    public function getMatches(string $puuidSummoner, ?Region $region = null, ?MatchFilter $filter = null): array;
+    public function getMatches(string $puuidSummoner, ?Platform $platform = null, ?MatchFilter $filter = null): array;
 
     /**
      * Get match details by match ID.
      *
      * @return array<string, mixed> Match data
      */
-    public function getMatch(string $idMatch, ?Region $region = null): array;
+    public function getMatch(string $idMatch, ?Platform $platform = null): array;
 
     /**
      * Get match timeline by match ID.
      *
      * @return array<string, mixed> Timeline data
      */
-    public function getMatchTimeline(string $idMatch, ?Region $region = null): array;
+    public function getMatchTimeline(string $idMatch, ?Platform $platform = null): array;
 }

--- a/src/DataLeague/Endpoint/SummonerApi.php
+++ b/src/DataLeague/Endpoint/SummonerApi.php
@@ -23,14 +23,14 @@ class SummonerApi implements SummonerApiInterface
     {
         $url = \sprintf(self::URL_SUMMONER, $puuid);
 
-        return $this->riotApiDataLeague->get($url, $platform)->toArray();
+        return $this->riotApiDataLeague->get($url, $platform ?? $this->riotApiDataLeague->getDefaultPlatform())->toArray();
     }
 
     public function getSummonerAsObject(string $puuid, ?Platform $platform = null): Summoner
     {
         $url = \sprintf(self::URL_SUMMONER, $puuid);
 
-        $summoner = $this->riotApiDataLeague->get($url, $platform)->toArray();
+        $summoner = $this->riotApiDataLeague->get($url, $platform ?? $this->riotApiDataLeague->getDefaultPlatform())->toArray();
 
         return $this->denormalizer->denormalize($summoner, Summoner::class);
     }

--- a/src/Enum/Platform.php
+++ b/src/Enum/Platform.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Zeggriim\RiotApiDataDragon\Enum;
 
-enum Platform: string
+enum Platform: string implements RoutingInterface
 {
     case BR1 = 'br1';
     case EUN1 = 'eun1';
@@ -22,4 +22,19 @@ enum Platform: string
     case TH2 = 'th2';
     case TW2 = 'tw2';
     case VN2 = 'vn2';
+
+    public function getRoutingKey(): string
+    {
+        return $this->value;
+    }
+
+    public function toRegion(): Region
+    {
+        return match ($this) {
+            self::BR1, self::LA1, self::LA2, self::NA1 => Region::AMERICAS,
+            self::EUN1, self::EUW1, self::RU, self::TR1 => Region::EUROPE,
+            self::JP1, self::KR => Region::ASIA,
+            self::OC1, self::PH2, self::SG2, self::TH2, self::TW2, self::VN2 => Region::SEA,
+        };
+    }
 }

--- a/src/Enum/Region.php
+++ b/src/Enum/Region.php
@@ -4,9 +4,15 @@ declare(strict_types=1);
 
 namespace Zeggriim\RiotApiDataDragon\Enum;
 
-enum Region: string
+enum Region: string implements RoutingInterface
 {
     case AMERICAS = 'americas';
     case ASIA = 'asia';
     case EUROPE = 'europe';
+    case SEA = 'sea';
+
+    public function getRoutingKey(): string
+    {
+        return $this->value;
+    }
 }

--- a/src/Enum/RoutingInterface.php
+++ b/src/Enum/RoutingInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zeggriim\RiotApiDataDragon\Enum;
+
+interface RoutingInterface
+{
+    public function getRoutingKey(): string;
+}

--- a/src/RiotApiDataLeagueClient.php
+++ b/src/RiotApiDataLeagueClient.php
@@ -12,7 +12,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 use Zeggriim\RiotApiDataDragon\DataLeague\RateLimit\RateLimitStatus;
 use Zeggriim\RiotApiDataDragon\Enum\Platform;
-use Zeggriim\RiotApiDataDragon\Enum\Region;
+use Zeggriim\RiotApiDataDragon\Enum\RoutingInterface;
 use Zeggriim\RiotApiDataDragon\Exception\DataNotFoundException;
 use Zeggriim\RiotApiDataDragon\Exception\ForbiddenException;
 use Zeggriim\RiotApiDataDragon\Exception\RequestException;
@@ -30,19 +30,18 @@ class RiotApiDataLeagueClient
     public function __construct(
         private readonly HttpClientInterface $riotLeague,
         private readonly string $apiKey,
-        private readonly Platform|Region $defaultPlatform = Platform::EUW1,
+        private readonly Platform $defaultPlatform = Platform::EUW1,
     ) {
     }
 
-    public function get(string $path, Platform|Region|null $platform = null): ResponseInterface
+    public function get(string $path, RoutingInterface $routing): ResponseInterface
     {
-        $platform = $platform ?? $this->defaultPlatform;
-        $url = \sprintf(self::URL, $platform->value).$path;
+        $url = \sprintf(self::URL, $routing->getRoutingKey()).$path;
 
         return $this->processRequest(Request::METHOD_GET, $url);
     }
 
-    public function getDefaultPlatform(): Platform|Region
+    public function getDefaultPlatform(): Platform
     {
         return $this->defaultPlatform;
     }

--- a/tests/DataLeague/Endpoint/AccountApiTest.php
+++ b/tests/DataLeague/Endpoint/AccountApiTest.php
@@ -8,7 +8,7 @@ use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\HttpClient\Exception\ClientException;
 use Symfony\Component\HttpClient\Exception\ServerException as ServerExceptionHttpClient;
 use Symfony\Component\HttpFoundation\Response;
-use Zeggriim\RiotApiDataDragon\Enum\Region;
+use Zeggriim\RiotApiDataDragon\Enum\Platform;
 use Zeggriim\RiotApiDataDragon\Exception\DataNotFoundException;
 use Zeggriim\RiotApiDataDragon\Exception\ForbiddenException;
 use Zeggriim\RiotApiDataDragon\Exception\RequestException;
@@ -38,7 +38,7 @@ final class AccountApiTest extends KernelTestCase
         ];
 
         $accountApi = $this->getAccountApi($dataResponse);
-        $account = $accountApi->getAccountByPuuid('test-puuid-12345', Region::EUROPE);
+        $account = $accountApi->getAccountByPuuid('test-puuid-12345', Platform::EUW1);
 
         self::assertArrayHasKey('puuid', $account);
         self::assertArrayHasKey('gameName', $account);
@@ -72,7 +72,7 @@ final class AccountApiTest extends KernelTestCase
         ];
 
         $accountApi = $this->getAccountApi($dataResponse, ['http_code' => 200]);
-        $account = $accountApi->getAccountByRiotId('AnotherPlayer', 'NA1', Region::EUROPE);
+        $account = $accountApi->getAccountByRiotId('AnotherPlayer', 'NA1', Platform::EUW1);
 
         self::assertArrayHasKey('puuid', $account);
         self::assertArrayHasKey('gameName', $account);
@@ -91,7 +91,7 @@ final class AccountApiTest extends KernelTestCase
         ];
 
         $accountApi = $this->getAccountApi($dataResponse);
-        $account = $accountApi->getAccountByAccessToken(Region::EUROPE);
+        $account = $accountApi->getAccountByAccessToken(Platform::EUW1);
 
         self::assertArrayHasKey('puuid', $account);
         self::assertArrayHasKey('gameName', $account);
@@ -111,7 +111,7 @@ final class AccountApiTest extends KernelTestCase
         $accountApi = $this->getAccountApi(['test' => 'test'], ['http_code' => $codeStatus]);
         self::expectException($exceptionClass);
         self::expectExceptionMessage($exceptionMessage);
-        $res = $accountApi->getAccountByPuuid('test-puuid', Region::EUROPE);
+        $res = $accountApi->getAccountByPuuid('test-puuid', Platform::EUW1);
         self::assertCount(0, $res);
     }
 

--- a/tests/DataLeague/Endpoint/MatchApiTest.php
+++ b/tests/DataLeague/Endpoint/MatchApiTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Zeggriim\RiotApiDataDragon\Tests\DataLeague\Endpoint;
 
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
-use Zeggriim\RiotApiDataDragon\Enum\Region;
+use Zeggriim\RiotApiDataDragon\Enum\Platform;
 use Zeggriim\RiotApiDataDragon\Tests\Traits\AssertMatchApiTrait;
 use Zeggriim\RiotApiDataDragon\Tests\Traits\RiotApiDataLeagueTrait;
 
@@ -3286,7 +3286,7 @@ final class MatchApiTest extends KernelTestCase
         ];
 
         $matchApi = $this->getMatchApi($dataResponse);
-        $match = $matchApi->getMatch('EUW1_6921668065', Region::EUROPE);
+        $match = $matchApi->getMatch('EUW1_6921668065', Platform::EUW1);
 
         $this->assertMatch($match, $dataResponse);
     }
@@ -41054,7 +41054,7 @@ final class MatchApiTest extends KernelTestCase
         ];
 
         $matchApi = $this->getMatchApi($dataResponse);
-        $match = $matchApi->getMatchTimeline('EUW1_6921668065', Region::EUROPE);
+        $match = $matchApi->getMatchTimeline('EUW1_6921668065', Platform::EUW1);
 
         $this->assertMatch($match, $dataResponse);
     }

--- a/tests/DataLeague/RateLimit/RateLimitStatusTest.php
+++ b/tests/DataLeague/RateLimit/RateLimitStatusTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\MockResponse;
 use Zeggriim\RiotApiDataDragon\DataLeague\RateLimit\RateLimitStatus;
+use Zeggriim\RiotApiDataDragon\Enum\Platform;
 use Zeggriim\RiotApiDataDragon\RiotApiDataLeagueClient;
 
 /**
@@ -105,7 +106,7 @@ final class RateLimitStatusTest extends TestCase
 
         self::assertNull($client->getLastRateLimitStatus());
 
-        $client->get('/lol/summoner/v4/summoners/by-puuid/test');
+        $client->get('/lol/summoner/v4/summoners/by-puuid/test', Platform::EUW1);
         $status = $client->getLastRateLimitStatus();
 
         self::assertInstanceOf(RateLimitStatus::class, $status);
@@ -132,11 +133,11 @@ final class RateLimitStatusTest extends TestCase
             'key'
         );
 
-        $client->get('/lol/summoner/v4/summoners/by-puuid/first');
+        $client->get('/lol/summoner/v4/summoners/by-puuid/first', Platform::EUW1);
         $statusAfterSuccess = $client->getLastRateLimitStatus();
 
         try {
-            $client->get('/lol/summoner/v4/summoners/by-puuid/second');
+            $client->get('/lol/summoner/v4/summoners/by-puuid/second', Platform::EUW1);
         } catch (\Throwable) {
         }
 

--- a/tests/DataLeague/RiotApiDataLeagueClientTest.php
+++ b/tests/DataLeague/RiotApiDataLeagueClientTest.php
@@ -7,6 +7,7 @@ namespace Zeggriim\RiotApiDataDragon\Tests\DataLeague;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\MockResponse;
+use Zeggriim\RiotApiDataDragon\Enum\Platform;
 use Zeggriim\RiotApiDataDragon\Exception\ServerLimitException;
 use Zeggriim\RiotApiDataDragon\RiotApiDataLeagueClient;
 
@@ -31,7 +32,7 @@ final class RiotApiDataLeagueClientTest extends TestCase
         $client = new RiotApiDataLeagueClient(new MockHttpClient($response, null), 'key');
 
         try {
-            $client->get('/lol/summoner/v4/summoners/by-puuid/test');
+            $client->get('/lol/summoner/v4/summoners/by-puuid/test', Platform::EUW1);
             self::fail('ServerLimitException expected');
         } catch (ServerLimitException $e) {
             self::assertSame(429, $e->getCode());
@@ -53,7 +54,7 @@ final class RiotApiDataLeagueClientTest extends TestCase
         $client = new RiotApiDataLeagueClient(new MockHttpClient($response, null), 'key');
 
         try {
-            $client->get('/lol/summoner/v4/summoners/by-puuid/test');
+            $client->get('/lol/summoner/v4/summoners/by-puuid/test', Platform::EUW1);
             self::fail('ServerLimitException expected');
         } catch (ServerLimitException $e) {
             self::assertSame(429, $e->getCode());
@@ -71,7 +72,7 @@ final class RiotApiDataLeagueClientTest extends TestCase
         $client = new RiotApiDataLeagueClient(new MockHttpClient($response, null), 'key');
 
         try {
-            $client->get('/lol/summoner/v4/summoners/by-puuid/test');
+            $client->get('/lol/summoner/v4/summoners/by-puuid/test', Platform::EUW1);
             self::fail('ServerLimitException expected');
         } catch (ServerLimitException $e) {
             self::assertSame(429, $e->getCode());
@@ -93,7 +94,7 @@ final class RiotApiDataLeagueClientTest extends TestCase
         $client = new RiotApiDataLeagueClient(new MockHttpClient($response, null), 'key');
 
         try {
-            $client->get('/lol/summoner/v4/summoners/by-puuid/test');
+            $client->get('/lol/summoner/v4/summoners/by-puuid/test', Platform::EUW1);
             self::fail('ServerLimitException expected');
         } catch (ServerLimitException $e) {
             self::assertSame(10, $e->retryAfter);

--- a/tests/Traits/RiotApiDataLeagueTrait.php
+++ b/tests/Traits/RiotApiDataLeagueTrait.php
@@ -19,6 +19,7 @@ use Zeggriim\RiotApiDataDragon\DataLeague\Serializer\Normalizer\ChampionMastery\
 use Zeggriim\RiotApiDataDragon\DataLeague\Serializer\Normalizer\ChampionMastery\ChampionMasteryNormalizer;
 use Zeggriim\RiotApiDataDragon\DataLeague\Serializer\Normalizer\ChampionMastery\NextSeasonMilestonesNormalizer;
 use Zeggriim\RiotApiDataDragon\DataLeague\Serializer\Normalizer\ChampionMastery\RewardConfigNormalizer;
+use Zeggriim\RiotApiDataDragon\Enum\Platform;
 use Zeggriim\RiotApiDataDragon\RiotApiDataLeagueClient;
 
 trait RiotApiDataLeagueTrait
@@ -96,6 +97,6 @@ trait RiotApiDataLeagueTrait
         $this->createMock(HttpClientInterface::class);
         $httpClient = new MockHttpClient($response, null);
 
-        return new RiotApiDataLeagueClient($httpClient, 'key');
+        return new RiotApiDataLeagueClient($httpClient, 'key', Platform::EUW1);
     }
 }


### PR DESCRIPTION
  Introduce RoutingInterface implemented by Platform and Region to
  replace the dual get()/getForRegion() methods on RiotApiDataLeagueClient
  with a single get(RoutingInterface) method.

  Add Platform::toRegion() based on the official Riot API routing table
  and add the missing Region::SEA for OC1/PH2/SG2/TH2/TW2/VN2 platforms.

  All endpoints (AccountApi, MatchApi) now accept ?Platform exclusively,
  deriving the region internally via toRegion(). The defaultRegion
  constructor parameter on RiotApiDataLeagueClient is removed.

  BREAKING CHANGE: AccountApi and MatchApi methods no longer accept
  a Region parameter — use Platform instead.
  RiotApiDataLeagueClient constructor no longer accepts a defaultRegion
  argument.